### PR TITLE
week8_기본과제 (step15) 주문 정보 외부 전송 기능을 이벤트 기반 구조로 변경

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java
@@ -1,9 +1,9 @@
 package kr.hhplus.be.server.application.order;
 
-import kr.hhplus.be.server.domain.coupon.Coupon;
 import kr.hhplus.be.server.domain.coupon.UserCoupon;
 import kr.hhplus.be.server.domain.coupon.service.GetCouponService;
 import kr.hhplus.be.server.domain.coupon.service.GetUserCouponService;
+import kr.hhplus.be.server.domain.order.event.OrderReportEventPublisher;
 import kr.hhplus.be.server.domain.order.service.CreateOrderService;
 import kr.hhplus.be.server.domain.order.service.GetOrderService;
 import kr.hhplus.be.server.domain.order.service.ValidatePaymentService;
@@ -37,6 +37,7 @@ public class OrderFacade {
     private final GetUserCouponService getUserCouponService;
     private final GetCouponService getCouponService;
     private final UpdateProductRankingService updateProductRankingService;
+    private final OrderReportEventPublisher orderReportEventPublisher;
 
     public OrderFacade(CreateOrderService createOrderService,
                        GetOrderService getOrderService,
@@ -46,7 +47,8 @@ public class OrderFacade {
                        RecordProductSaleService recordProductSaleService,
                        MockOrderReporter reporter, GetUserCouponService getUserCouponService,
                        GetCouponService getCouponService,
-                       UpdateProductRankingService updateProductRankingService) {
+                       UpdateProductRankingService updateProductRankingService,
+                       OrderReportEventPublisher orderReportEventPublisher) {
         this.createOrderService = createOrderService;
         this.getOrderService = getOrderService;
         this.validatePaymentService = validatePaymentService;
@@ -57,6 +59,7 @@ public class OrderFacade {
         this.getUserCouponService = getUserCouponService;
         this.getCouponService = getCouponService;
         this.updateProductRankingService = updateProductRankingService;
+        this.orderReportEventPublisher = orderReportEventPublisher;
     }
 
     public OrderResult order(CreateOrderCommand command) {
@@ -116,7 +119,8 @@ public class OrderFacade {
                 (int) updated.point()
         );
 
-        reporter.send(order.toResponse((int) updated.point()));
+//        reporter.send(order.toResponse((int) updated.point()));
+        orderReportEventPublisher.publish(order.toResponse((int) updated.point()));
 
         return result;
     }

--- a/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEvent.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.domain.order.event;
+
+import kr.hhplus.be.server.interfaces.api.order.OrderResponse;
+
+public class OrderReportEvent {
+    private final OrderResponse response;
+
+    public OrderReportEvent(OrderResponse response) {
+        this.response = response;
+    }
+
+    public OrderResponse getResponse() {
+        return response;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEventListener.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.domain.order.event;
+
+import kr.hhplus.be.server.infrastructure.mock.MockOrderReporter;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderReportEventListener {
+
+    private final MockOrderReporter reporter;
+
+    public OrderReportEventListener(MockOrderReporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @EventListener
+    public void handle(OrderReportEvent event) {
+        reporter.send(event.getResponse());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/event/OrderReportEventPublisher.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.domain.order.event;
+
+import kr.hhplus.be.server.domain.order.event.OrderReportEvent;
+import kr.hhplus.be.server.interfaces.api.order.OrderResponse;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderReportEventPublisher {
+
+    private final ApplicationEventPublisher publisher;
+
+    public OrderReportEventPublisher(ApplicationEventPublisher publisher) {
+        this.publisher = publisher;
+    }
+
+    public void publish(OrderResponse response) {
+        publisher.publishEvent(new OrderReportEvent(response));
+    }
+}


### PR DESCRIPTION
## 📦 PR 제목
[step15] 주문 정보 외부 전송 기능을 이벤트 기반 구조로 변경

---

## ✨ 주요 변경 사항

- `OrderFacade`에서 `MockOrderReporter` 직접 호출 제거
- 주문 완료 후 외부 시스템으로 주문 정보를 전송하는 기능을 **이벤트 기반 구조**로 리팩토링
- 다음 구성 요소를 추가 및 적용:
    - `OrderReportEvent`: 주문 정보를 담은 이벤트 페이로드 클래스
    - `OrderReportEventPublisher`: `ApplicationEventPublisher`를 통해 이벤트를 발행하는 퍼블리셔
    - `OrderReportEventListener`: 이벤트를 수신해 외부 시스템(MOCK)으로 전송 처리
---

## 🔗 관련 커밋

- f3419fd:  
  `[step15] order의 주문정보 외부시스템 전송 기능 이벤트 기반 구조로 변경`
    - OrderFacade에서 `MockOrderReporter` 직접 호출 제거
    - `OrderReportEvent`, `OrderReportEventPublisher`, `OrderReportEventListener` 추가