### PR TITLE
week9_기본과제 (step17) Kafka 기초 학습 및 활용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
 	// AOP 기능을 위한 의존성 추가
 	implementation("org.springframework.boot:spring-boot-starter-aop")
 
+	// Kafka
+	implementation("org.springframework.kafka:spring-kafka")
+
 	// Test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: '3.8'
+
 services:
   mysql:
     image: mysql:8.0
@@ -11,6 +12,8 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+    networks:
+      - backend
 
   redis:
     image: redis:7
@@ -21,7 +24,35 @@ services:
       redis-server
       --maxmemory 512mb
       --maxmemory-policy allkeys-lru
+    networks:
+      - backend
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.2.1
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - backend
+
+  kafka:
+    image: confluentinc/cp-kafka:7.2.1
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - backend
 
 networks:
-  default:
+  backend:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/example/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/example/kafka/KafkaMessageConsumer.java
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.example.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaMessageConsumer {
+
+    @KafkaListener(topics = "test-topic", groupId = "test-consumer")
+    public void listen(String message) {
+        System.out.println("수신된 메시지: " + message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/example/kafka/KafkaMessageProducer.java
+++ b/src/main/java/kr/hhplus/be/server/example/kafka/KafkaMessageProducer.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.example.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaMessageProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaMessageProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void send(String topic, String message) {
+        kafkaTemplate.send(topic, message);
+        System.out.println("메시지 전송 완료: " + message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/example/kafka/KafkaTestController.java
+++ b/src/main/java/kr/hhplus/be/server/example/kafka/KafkaTestController.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.example.kafka;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/kafka")
+public class KafkaTestController {
+
+    private final KafkaMessageProducer producer;
+
+    public KafkaTestController(KafkaMessageProducer producer) {
+        this.producer = producer;
+    }
+
+    @GetMapping("/send")
+    public String send(@RequestParam String message) {
+        producer.send("test-topic", message);
+        return "메시지 전송: " + message;
+    }
+}
+

--- a/src/main/java/kr/hhplus/be/server/infrastructure/mock/MockOrderReporter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/mock/MockOrderReporter.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.infrastructure.mock;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import kr.hhplus.be.server.infrastructure.report.kafka.OrderReportMessage;
 import kr.hhplus.be.server.interfaces.api.order.OrderResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,8 +23,17 @@ public class MockOrderReporter {
 
     public void send(OrderResponse orderResponse) {
         try {
-            String payload = objectMapper.writeValueAsString(orderResponse);
-            log.info("[외부 데이터 플랫폼 전송됨] {}", payload);
+            String message = objectMapper.writeValueAsString(orderResponse);
+            log.info("[외부 데이터 플랫폼 전송됨] {}", message);
+        } catch (JsonProcessingException e) {
+            log.warn("[전송 실패] JSON 직렬화 에러", e);
+        }
+    }
+
+    public void sendMessage(OrderReportMessage message) {
+        try {
+            String payload = objectMapper.writeValueAsString(message);
+            log.info("[외부 데이터 플랫폼 전송됨] {}", message);
         } catch (JsonProcessingException e) {
             log.warn("[전송 실패] JSON 직렬화 에러", e);
         }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/report/kafka/OrderReportEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/report/kafka/OrderReportEventPublisher.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.infrastructure.report.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderReportEventPublisher {
+
+    private final KafkaTemplate<String, OrderReportMessage> kafkaTemplate;
+
+    public OrderReportEventPublisher(KafkaTemplate<String, OrderReportMessage> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void publish(OrderReportMessage message) {
+        try {
+            kafkaTemplate.send("order-report-topic", message);
+        } catch (Exception e) {
+            // 로깅만 하고 예외는 흘려보내지 않음
+            // 테스트나 운영 환경에 따라 필요시 Alert 처리
+            System.err.println("[Kafka 전송 실패] " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/report/kafka/OrderReportMessage.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/report/kafka/OrderReportMessage.java
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.infrastructure.report.kafka;
+
+import java.time.LocalDateTime;
+
+public record OrderReportMessage(
+        Long orderId,
+        int totalPrice,
+        int discount,
+        int finalPrice,
+        LocalDateTime orderedAt
+) {}

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/report/kafka/OrderReportListener.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/report/kafka/OrderReportListener.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.interfaces.api.report.kafka;
+
+import kr.hhplus.be.server.infrastructure.mock.MockOrderReporter;
+import kr.hhplus.be.server.infrastructure.report.kafka.OrderReportMessage;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderReportListener {
+
+    private final MockOrderReporter reporter;
+
+    public OrderReportListener(MockOrderReporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @KafkaListener(topics = "order-report-topic", groupId = "report-group")
+    public void listen(OrderReportMessage message) {
+        reporter.sendMessage(message);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,16 @@ spring:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
     defer-datasource-initialization: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: test-consumer
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 ---
 spring.config.activate.on-profile: local, test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,20 +24,22 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
-      group-id: test-consumer
+      group-id: report-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.value.default.type: kr.hhplus.be.server.infrastructure.report.kafka.OrderReportMessage
+        spring.json.trusted.packages: "*"
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 ---
 spring.config.activate.on-profile: local, test
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:3307/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
 


### PR DESCRIPTION
## 📦 PR 제목
 [step17] Kafka 기반 주문 리포트 메시지 송수신 기능 추가

---

## ✨ 주요 변경 사항

### 📌 Kafka 기반 메시지 송수신 기능 구현

- Kafka를 이용한 비동기 메시지 발행 및 수신 구조 도입
- 테스트용 Kafka Producer/Consumer 클래스 작성
- 주문 완료 시 OrderReportMessage를 Kafka로 발행 → 수신 후 후속 처리

## 도메인 이벤트 연동
- OrderReportEventPublisher: Kafka로 메시지 발행 담당
- OrderReportListener: Kafka 메시지 수신 후 처리
- 기존 주문 처리 흐름에 Kafka 발행 로직을 이벤트 기반으로 통합

## 테스트 및 예제 API 제공
- KafkaTestController: `/kafka/send?message=` API로 메시지 발행 가능
- KafkaMessageProducer / KafkaMessageConsumer로 메시지 송수신 확인 가능

## 환경 구성 변경
- docker-compose.yml: Kafka + Zookeeper 설정 추가
- application.yml: Kafka 설정 추가 (bootstrap-servers, serializer 등)
- build.gradle.kts: Spring for Apache Kafka 의존성 추가

--- 

## 🔗  관련 커밋
- 095e260: Kafka 메시지 송수신 기능 및 테스트 컨트롤러 추가 (kafka 메세지 흐름 확인용 테스트)
- 140aafb: Kafka 기반 주문 리포트 이벤트 발행 및 수신 기능 추가

- Kafka 기본 개념 및 동작 : https://chain-methane-b1d.notion.site/Chapter-3-4-_Kafka-20017390d925807791f5d96fb1cc2ef3?pvs=4
- Kafka 실습 환경 구축 및 단일 메시지 흐름 테스트 구현 : https://chain-methane-b1d.notion.site/Chapter-3-4-_Kafka-20017390d9258095ac58e634e136ca4d?pvs=4


