### PR TITLE
week10_기본과제(step19) k6 부하 테스트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+#version: '3.8'
 
 services:
   mysql:
@@ -50,6 +50,28 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - backend
+
+  influxdb:
+    image: influxdb:1.8
+    container_name: influxdb
+    ports:
+      - "8086:8086"
+    volumes:
+      - ./data/influxdb:/var/lib/influxdb
+    networks:
+      - backend
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - influxdb
+    volumes:
+      - ./data/grafana:/var/lib/grafana
     networks:
       - backend
 


### PR DESCRIPTION
## [week10] K6 부하 테스트 시각화를 위한 Grafana 연동 환경 구성

---

### 📌 주요 변경 사항
10237ca 
- `docker-compose.yml`에 **InfluxDB** 및 **Grafana** 설정 추가  
  → K6 부하 테스트 결과를 InfluxDB에 저장하고, Grafana를 통해 시각화 가능하도록 구성
- K6 실행 시 `--out influxdb=http://localhost:8086/k6` 형태로 연동 가능
- Grafana에서 주요 K6 메트릭을 시각화하기 위한 기본 대시보드 구성
    - 예: `http_reqs`, `http_req_duration`, `http_req_failed` 등

---

### 🛠 기타 참고 사항

- InfluxDB는 **1.8 버전** 사용
- Grafana는 기본 포트 `3000`에서 실행됨 (`http://localhost:3000`)
- 대시보드는 추후 export/import 가능 (JSON 기반 구성)

---

###  부하 테스트 계획 및 수행 보고서

https://chain-methane-b1d.notion.site/Chapter-4-20917390d92580c5b577fba68bd2caed?source=copy_link


---

### 리뷰 포인트

코치님 안녕하세요.

벌써 10주가 지나 마무리 인사를 드리게 되니 시간이 참 빠르면서도 아쉬움이 많이 남습니다.
그동안 정말 고생 많으셨고, 진심으로 감사드립니다.

코치님을 만나고 나서 개발과 백엔드 직무에 대한 제 생각이 많이 바뀌었고,
일하는 태도 또한 더 성숙하게 변할 수 있었습니다. (물론 좋은 방향으로요 😊)

멘토링 시간에 해주셨던 말씀 하나하나 마음에 새기고,
항해 이후에도 계속 성장해서 원하는 곳에 이직하게 되면 꼭 연락드리겠습니다.

그동안 정말 감사했습니다!
